### PR TITLE
feat: 프로미스 구현

### DIFF
--- a/promise-Implementing/promise-구현.js
+++ b/promise-Implementing/promise-구현.js
@@ -1,0 +1,201 @@
+const PROMISES_STATE = {
+  pending: "pending",
+  fulfilled: "fulfilled",
+  rejected: "rejected",
+};
+
+class MyPromise {
+  value = null;
+  state = PROMISES_STATE.pending;
+  thenCallbacks = [];
+  catchCallbacks = [];
+
+  constructor(executor) {
+    try {
+      executor(this.resolve.bind(this), this.reject.bind(this));
+    } catch (error) {
+      this.reject(error);
+    }
+  }
+
+  runCallbacks() {
+    if (this.state === PROMISES_STATE.fulfilled) {
+      this.thenCallbacks.forEach((cb) => cb(this.value));
+      // this.thenCallbacks = []; // 질문 [Q1]
+    }
+    if (this.state === PROMISES_STATE.rejected) {
+      this.catchCallbacks.forEach((cb) => cb(this.value));
+      // this.catchCallbacks = []; // 질문 [Q1]
+    }
+  }
+
+  update(updateState, value) {
+    queueMicrotask(() => {
+      if (this.state !== PROMISES_STATE.pending) return;
+
+      // [TODO] Promise 안에서 Promise 리턴 하는 경우 <- 잘 이해가 안되서 일단 스킵
+      // value가 프로미스 인스턴스 객체인지 확인
+      // if (value instanceof MyPromise) {
+      //   value.then(this.resolve.bind(this), this.reject.bind(this));
+      //   return;
+      // }
+
+      this.state = updateState;
+      this.value = value;
+      this.runCallbacks();
+    });
+  }
+
+  resolve(value) {
+    this.update(PROMISES_STATE.fulfilled, value);
+  }
+
+  reject(value) {
+    this.update(PROMISES_STATE.rejected, value);
+  }
+
+  then(thenCallback, catchCallback) {
+    return new MyPromise((resolve, reject) => {
+      this.thenCallbacks.push((value) => {
+        if (!thenCallback) {
+          resolve(value);
+          return;
+        }
+        try {
+          resolve(thenCallback(value));
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      this.catchCallbacks.push((value) => {
+        if (!catchCallback) {
+          reject(value);
+          return;
+        }
+        try {
+          resolve(catchCallback(value));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  catch(catchCallback) {
+    return this.then(undefined, catchCallback);
+  }
+
+  finally(callback) {
+    return this.then(
+      (value) => {
+        callback();
+        return value;
+      },
+      (value) => {
+        callback();
+        return value;
+      }
+    );
+  }
+}
+
+// 실행코드
+const promise = new MyPromise((resolve, reject) => {
+  setTimeout(() => {
+    resolve("성공1");
+  }, 1000);
+});
+
+promise
+  .then((result) => {
+    console.log("then-1", result); // ✔️ 성공1
+    throw new Error();
+  })
+  .then((result) => {
+    console.log("then-2", result);
+    return "성공3";
+  })
+  .catch((error) => {
+    console.log("catch :" + error); // ✔️ Error
+    return "실패";
+  })
+  .then((result) => {
+    console.log("then-3", result); // ✔️  "실패"
+    return "성공4";
+  })
+  .finally(() => {
+    console.log("finally");
+  });
+
+// 실행코드 async-awiat
+/*
+  async function asyncFunc() {
+    try {
+      const result1 = await new Promise((resolve) => {
+        setTimeout(() => {
+          resolve("성공1");
+        }, 1000);
+      });
+      console.log("then-1", result1); // ✔️ 성공1
+  
+      // 강제로 에러 발생
+      throw new Error();
+    } catch (error) {
+      console.log("catch :" + error); // ✔️ Error
+      return "실패";
+    }
+  }
+  
+  async function promise2() {
+    const result2 = await asyncFunc();
+    console.log("then-3", result2); // ✔️ "실패"
+    return "성공4";
+  }
+  
+  promise2();
+  */
+
+// <질문 & 보완 필요 부분>  ----------------------------------------------------------------------
+
+// [Q1] - 왜 runCallbacks 메서드 실행 이후, this.thenCallbacks = []; 왜 초기화를 해줘야 하는지?
+// 어차피 다음 프로미스 인스턴스 객체로 실행이 넘어가는데?
+
+// [2] - Promise 안에서 Promise 리턴 하는 경우 <- 잘 이해가 안되서 일단 스킵
+
+// [3] - 타입스크립트 미적용. js 코드 파악만으로도 여유가 없었음
+
+// <노트> ------------------------------------------------------------------------------------
+/**
+ * [P1] - executor(this.resolve.bind(this), this.reject.bind(this));
+ * this 바인딩 해줘야 this는 프로미스 인스턴스 객체가 제대로 됨.
+ * 안하면 this는 window 여서 resolve 못찾음.
+ *
+ * 이유
+ * setTimeout(() => { resolve("성공1");}
+ * setTimeout에서 this는 window이고, resolve는 그냥 함수 호출이기 때문에, resolve안의 this도 window임.
+ */
+
+/**
+ * [P2] - resolve(catchCallback(value));
+ * reject(catchCallback(value)) 아님!
+ *
+ * catch 는 : 비동기 작업에서 실패(reject) 상태를 처리하는 메서드
+ * catch 는 이미 실패 상태를 처리한 뒤, 다음 체이닝은 연결해야 하기 때문에 (catch()."then()")
+ * resolve를 호출해 새로운 성공 상태로 전환하는 것임.
+ *
+ * catch 콜백함수의 반환 값을 resolve한 새 Promise를 반환하는 것임.
+ */
+
+/**
+ * [P2] - finally
+ * finally도 프로미스를 반환한다.
+ * then,catch,finally 모두 콜백함수의 반환 값(없으면 undefined)을 resolve 한 프로미스를 반환 하는 것이다.
+ */
+
+/**
+ * [P3] - queueMicrotask()
+ * 왜 Queue에 저장해두는가?
+ * : 비동기 작업의 순서를 보장하기 위해
+ * : 큐가 없으면, setTimeout 콜백함수의 resolve 기다리지 않고, then 콜백함수가 먼저 바로 resolve 되버림!
+ */

--- a/promise-Implementing/promise.ts
+++ b/promise-Implementing/promise.ts
@@ -51,31 +51,41 @@ class MyPromise_<T> {
   }
 
   then<U>(
-    thenCallback?: (x: T) => MyPromise_<U> | Promise<U>,
-    catchCallback?: (ex: any) => MyPromise_<U> | Promise<U>
+    thenCallback?: (x: T) => MyPromise_<U> | Promise<U> | U,
+    catchCallback?: (ex: any) => MyPromise_<U> | Promise<U> | U
   ): MyPromise_<U> {
     return new MyPromise_<U>((resolve, reject) => {
-      this.thenCallbacks.push(async (value) => {
+      this.thenCallbacks.push((value) => {
         if (!thenCallback) {
           resolve(value as unknown as U);
           return;
         }
+
         try {
-          const v = await thenCallback(value);
-          resolve(v);
+          const result = thenCallback(value);
+          if (result instanceof MyPromise_ || result instanceof Promise) {
+            (result as MyPromise_<any>).then(resolve, reject);
+          } else {
+            resolve(result);
+          }
         } catch (error) {
           reject(error);
         }
       });
 
-      this.catchCallbacks.push(async (value) => {
+      this.catchCallbacks.push((value) => {
         if (!catchCallback) {
           reject(value);
           return;
         }
+
         try {
-          const v = await catchCallback(value);
-          resolve(v);
+          const result = catchCallback(value);
+          if (result instanceof MyPromise_ || result instanceof Promise) {
+            (result as MyPromise_<any>).then(resolve, reject);
+          } else {
+            resolve(result as U);
+          }
         } catch (error) {
           reject(error);
         }
@@ -103,7 +113,7 @@ class MyPromise_<T> {
   }
 }
 
-// 실행 - promise 또 반환 ----------------------------------
+// 실행 - promise에서 promise 또 반환 ----------------------------------
 const promise = new MyPromise_((resolve, reject) => {
   setTimeout(() => {
     resolve("성공1");
@@ -111,23 +121,34 @@ const promise = new MyPromise_((resolve, reject) => {
 });
 
 promise
-  .then(async (result) => {
-    console.log("then-1", result); // ✔️ 성공1
+  .then((result) => {
+    console.log("then-1", result); //  then-1 성공1
     return new MyPromise_((resolve, reject) => {
-      setTimeout(async () => {
-        resolve("Succuess1");
-      }, 1000);
+      resolve("성공2");
     });
   })
-  .then(async (result) => {
-    console.log("then-2", result); // ✔️  "Succuess1"
-    throw new Error();
-  })
-  .then(async (result) => {
-    console.log("catch-1", result);
-    throw "성공2";
-  })
-  .catch(async (result) => {
-    console.log("then-3", result); // ✔️ Error
-    return "성공4";
+  .then((result) => {
+    console.log("then-2", result); // then-2 성공2
+    return "성공3";
   });
+
+/**
+ * 노트
+ *
+ * <then에서 또 프로미스 반환되는 로직>
+ * [1] thenCallback(value);실행 -> 서브 프로미스 반환 -> 서브 프로미스 resolve 실행
+ * -> update(fillfied , 성공2) -> 큐에 서브 프로미스 콜백 등록 (서브프로미스 resolve대기상태)
+ *
+ * [2] 동기 코드 남은거 실행  const result = 서브 프로미스{queue에서 resolve 대기상태}
+ * result가 프로미스 인스턴스 객체여서
+ * if (result instanceof MyPromise_ || result instanceof Promise) {} 에 걸림
+ *
+ * [3] result.then("resolve") 실행. 서브 프로미스{큐 resolve 대기}.then(resolve) 실행되는 것임.
+ * 이때의 resolve는 then프로미스를 this로 하는 resolve임!!!
+ *
+ * [4] 서브 프로미스의 this에 this.thenCallbacks에 Push 하고 끝
+ * [5] 동기 다 끝났으니, 큐에 넣어놓은 서브 프로미스 콜백 실행됨. this.value = 성공2
+ * [6] this.runCallbacks 실행 -> 4에서 push헤놔서 저장된 thenCbs 실행
+ * [7] resolve(성공2)가 실행되는데, 이때 resolve는 then프로미스꺼임
+ * 때문에 then 프로미스의 값이 리졸브되서 -> 다음 then으로 채이닝
+ */

--- a/promise-Implementing/promise.ts
+++ b/promise-Implementing/promise.ts
@@ -1,0 +1,129 @@
+enum PROMISES_STATE_ {
+  pending = "pending",
+  fulfilled = "fulfilled",
+  rejected = "rejected",
+}
+
+class MyPromise_<T> {
+  value?: T;
+  state = PROMISES_STATE_.pending;
+  thenCallbacks: ((x: T) => void)[] = [];
+  catchCallbacks: ((ex: any) => void)[] = [];
+
+  constructor(
+    executor: (resolve: (x: T) => void, reject: (ex: any) => void) => void
+  ) {
+    try {
+      executor(this.resolve.bind(this), this.reject.bind(this));
+    } catch (error) {
+      this.reject(error);
+    }
+  }
+
+  runCallbacks() {
+    if (this.state === PROMISES_STATE_.fulfilled) {
+      this.thenCallbacks.forEach((cb) => cb(this.value!));
+      this.thenCallbacks = [];
+    }
+    if (this.state === PROMISES_STATE_.rejected) {
+      this.catchCallbacks.forEach((cb) => cb(this.value));
+      this.catchCallbacks = [];
+    }
+  }
+
+  update(updateState: PROMISES_STATE_, value?: T) {
+    queueMicrotask(() => {
+      if (this.state !== PROMISES_STATE_.pending) return;
+
+      // [TODO] Promise 안에서 Promise 리턴 하는 경우 <- 잘 이해가 안되서 일단 스킵
+      // value가 프로미스 인스턴스 객체인지 확인
+      // if (value instanceof MyPromise_) {
+      //   value.then(this.resolve.bind(this), this.reject.bind(this));
+      //   return;
+      // }
+
+      this.state = updateState;
+      this.value = value;
+      this.runCallbacks();
+    });
+  }
+
+  resolve(value: T) {
+    if (this.state !== PROMISES_STATE_.pending) return;
+    this.update(PROMISES_STATE_.fulfilled, value);
+  }
+
+  reject(ex: any) {
+    if (this.state !== PROMISES_STATE_.pending) return;
+    this.update(PROMISES_STATE_.rejected, ex);
+  }
+
+  then<U>(
+    thenCallback?: (x: T) => MyPromise_<U>,
+    catchCallback?: (ex: any) => MyPromise_<U>
+  ): MyPromise_<U> {
+    return new MyPromise_<U>((resolve, reject) => {
+      this.thenCallbacks.push((value) => {
+        if (!thenCallback) {
+          resolve(value);
+          return;
+        }
+        try {
+          resolve(thenCallback(value));
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      this.catchCallbacks.push((value) => {
+        if (!catchCallback) {
+          reject(value);
+          return;
+        }
+        try {
+          resolve(catchCallback(value));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  catch<U>(catchCallback: (ex: any) => MyPromise_<U>): MyPromise_<U> {
+    return this.then(undefined, catchCallback);
+  }
+
+  finally<U>(callback: (ex: any) => MyPromise_<U>): MyPromise_<U> {
+    return this.then(
+      (value) => {
+        callback();
+        return value;
+      },
+      (value) => {
+        callback();
+        return value;
+      }
+    );
+  }
+}
+
+// 실행 - promise 또 반환 ----------------------------------
+const promise = new MyPromise_((resolve, reject) => {
+  setTimeout(() => {
+    resolve("성공1");
+  }, 1000);
+});
+
+promise
+  .then(async (result) => {
+    console.log("then-1", result); // ✔️ 성공1
+    return new MyPromise_((resolve, reject) => {
+      setTimeout(async () => {
+        resolve("Succuess1");
+      }, 1000);
+    });
+  })
+  .then(async (result) => {
+    console.log("then-2", result); // ✔️  "Succuess1"
+    return "성공4";
+  });


### PR DESCRIPTION
프로미스 구현 - [fa9509a](https://github.com/jihyun-jeon/TIL/pull/1/commits/fa9509a1f562a6d0e38d559528b75796d6452839)

then메서드의 콜백함수에 모두 async가 붙었다고 생각하고 구현해보았습니다.
이렇게하니 프로미스에서 또 프로미스 반환하는 경우도 쉽게 생각할 수 있었던 것 같아요!


**[기능]**
- then,catch,finally 메서드 구현
- 프로미스 체이닝 가능
- async-await 으로도 실행 가능
- Promise 안에서 Promise 리턴 하는 경우 가능

**[보완 사항]**
- ts 오류 해결